### PR TITLE
Prevent crash if attribute 'radius' is not present

### DIFF
--- a/gerber_to_scad.py
+++ b/gerber_to_scad.py
@@ -103,7 +103,7 @@ def primitive_to_shape(p):
         # If a non-zero aperture size is set, we'll draw rectangles (ignoring the circular edges for now)
         # otherwise we'll just use the lines directly (they're later joined into shapes)
 
-        if p.aperture.radius:
+        if hasattr(p.aperture, 'radius') and p.aperture.radius:
             vertices = rect_from_line(p)
         else:
             v1 = make_v(p.start)


### PR DESCRIPTION
To prevent exception:

```
Traceback (most recent call last):
  File "gerber_to_scad.py", line 371, in <module>
    args.increase_hole_size
  File "gerber_to_scad.py", line 287, in process
    outline_shape = create_outline_shape(outline_file)
  File "gerber_to_scad.py", line 160, in create_outline_shape
    outline_vertices += primitive_to_shape(p)
  File "gerber_to_scad.py", line 106, in primitive_to_shape
    if has_attr(p.aperture, 'radius') and p.aperture.radius:
# This is Git's per-user configuration file.
NameError: global name 'has_attr' is not defined

```
