### PR TITLE
Remove link to archived repo from Django site footer

### DIFF
--- a/gts_service/templates/main.html
+++ b/gts_service/templates/main.html
@@ -174,10 +174,8 @@ $( document ).ready(function() {
       href="https://www.djangoproject.com/" target="_blank">Django</a>.
   </p>
 
-  <p>You can find the code for the underlying converter at <a href="https://github.com/kirberich/gerber_to_scad"
-      target="_blank">https://github.com/kirberich/gerber_to_scad</a>. The code for the web app can be found at <a
-      href="https://github.com/kirberich/gerber_to_scad_service"
-      target="_blank">https://github.com/kirberich/gerber_to_scad_service</a>.</p>
+  <p>You can find the code for the underlying converter and web app at <a href="https://github.com/kirberich/gerber_to_scad"
+      target="_blank">https://github.com/kirberich/gerber_to_scad</a>.</p>
 
   <p>Version {{version}}</p>
 


### PR DESCRIPTION
Love the site (https://solder-stencil.me). Thanks for hosting it! 

Just wanted to remove the link to the now-archived website repo, as it may lead people (like myself, almost) to think this project is unsupported and defunct. 