### PR TITLE
Move CLI handler into python package folder, update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+venv/
+.venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # gerber_to_scad
 Simple python script for converting gerber files into a 3d printable solder stencil scad file
 
-## Installation
-gerber to scad requires python3.9
+This repository has both a CLI tool, and a web app available at https://solder-stencil.me.
 
-* Make sure you have (poetry)[https://python-poetry.org/docs/] installed
-* Run poetry install
+## Installation
+
+`gerber_to_scad` requires python3.9.
+
+* Make sure you have [poetry](https://python-poetry.org/docs/) installed.
+* Run `poetry install`.
 
 Note: on M1 macs, scipy doesn't install correctly out of the box. If you're getting installation errors, try this:
 
@@ -21,7 +24,9 @@ poetry install
 You should now be able to run the script. You'll get some information on available options if you run it with the -h argument:
 
 ```bash
-(env) $ python main.py -h
+(env) $ gerber_to_scad -h
+# Or:
+(env) $ python -m gerber_to_scad -h
 usage: main.py [-h] [-t THICKNESS] [-n] [-L LEDGE_THICKNESS] [-g GAP]
                          [-i INCREASE_HOLE_SIZE]
                          outline_file solderpaste_file output_file
@@ -57,5 +62,5 @@ optional arguments:
 For basic usage, simply run the script with input files for the gerber outline and solderpaste files and specify an output:
 
 ```bash
-python main.py outline_file.gko toppaste_file.gtp output.scad
+gerber_to_scad outline_file.gko toppaste_file.gtp output.scad
 ```

--- a/gerber_to_scad/__main__.py
+++ b/gerber_to_scad/__main__.py
@@ -1,4 +1,5 @@
-from .conversion import process_gerber
+"""`__main__.py` file adds support for running like: `python -m gerber_to_scad -h`."""
+
 from .cli import gerber_to_scad_cli
 
 if __name__ == "__main__":

--- a/gerber_to_scad/cli.py
+++ b/gerber_to_scad/cli.py
@@ -1,8 +1,11 @@
+"""CLI entry point for gerber_to_scad."""
+
 import argparse
-from gerber_to_scad import process_gerber
 import gerber
 
-if __name__ == "__main__":
+from .conversion import process_gerber
+
+def gerber_to_scad_cli():
     parser = argparse.ArgumentParser(
         description="Convert gerber files to an scad 3d printable solder stencil."
     )
@@ -87,3 +90,6 @@ if __name__ == "__main__":
                 stencil_margin=0,
             )
         )
+
+if __name__ == "__main__":
+    gerber_to_scad_cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 authors = ["Your Name <you@example.com>"]
 description = ""
 name = "gerber_to_scad"
-version = "0.1.0"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
 Django = "^4.2"
@@ -18,10 +18,13 @@ taskipy = "^1.10.4"
 [tool.poetry.dev-dependencies]
 black = "^23.3.0"
 
+[tool.poetry.scripts]
+gerber_to_scad = "gerber_to_scad.cli:gerber_to_scad_cli"
+
 [build-system]
 build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core>=1.0.0"]
 
 [tool.taskipy.tasks]
-g2s = "python gerber_to_scad/gerber_to_scad.py"
+g2s = "python gerber_to_scad/cli.py"
 service = "gunicorn --workers 1 --threads 8 gts_service.wsgi"


### PR DESCRIPTION
This PR moves the `main.py` CLI entry point into the Python package, as is standard in modern and properly-packaged Python projects.

Now, instead of `python main.py`, the ways of calling the tool are:

```bash
(env) $ gerber_to_scad -h
# Or:
(env) $ python -m gerber_to_scad -h
```

This adds the added benefit of being able to be published to PyPI and/or installed completely with `pipx` (a lighter-weight and more standard installation than Poetry, which many people prefer not to use). 

Let me know if you have any questions or would like me to help change anything! 